### PR TITLE
Integration with Home Assistant: configuration.yaml, sensor: force_update: true

### DIFF
--- a/integrationWithHomeAssistant.md
+++ b/integrationWithHomeAssistant.md
@@ -15,6 +15,7 @@ sensor:
     - platform: mqtt
       name: "People counter"
       state_topic: "peopleCounter/serialdata/tx"
+      force_update: true
 ```
 
 The state topic must contain whatever is saved as `define_mqtt_serial_publish_ch` in the file `peopleCounter.ino`.


### PR DESCRIPTION
If someone walks in one direction the sensor outputs 1 and is not returning to 0 afterwards. It just stays 1 (that's how it is in my case). The problem: If someone else walks in the same direction (e.g. two people in a room now) the sensor is not updating itself (since it is already 1). Hence there is no update of the input number and the input number never goes higher than 1. I tested the sensor and your code and ran in this problem. The force_update: true command fixed it for me.