### PR TITLE
Use of a counter instead of a input_number

### DIFF
--- a/integrationWithHomeAssistant.md
+++ b/integrationWithHomeAssistant.md
@@ -2,7 +2,7 @@
 
 In order to integrate this sensor inside your Home Assistant setup, the following chunks of code need to be added to the appropriate files.
 
-**We will have to define an counter**, that simply will count the number of people inside the room. It will be called `counter.people_in_the_room`
+**We will have to define a counter**, that simply will count the number of people inside the room. It will be called `counter.people_in_the_room`
 
 
 #### automations.yaml

--- a/integrationWithHomeAssistant.md
+++ b/integrationWithHomeAssistant.md
@@ -2,7 +2,7 @@
 
 In order to integrate this sensor inside your Home Assistant setup, the following chunks of code need to be added to the appropriate files.
 
-**We will have to define an input number**, that simply will count the number of people inside the room. It will be called `input_number.people_in_the_room`
+**We will have to define an counter**, that simply will count the number of people inside the room. It will be called `counter.people_in_the_room`
 
 
 #### automations.yaml
@@ -10,69 +10,73 @@ In order to integrate this sensor inside your Home Assistant setup, the followin
 We now need to define two automations that will allow us to understand when someone is getting in or out of the room. This first one will take account of the first case.
 
 ```yaml
-alias: 'Person entering the room'
-trigger:
+- alias: 'Person entering the room'
+  description: ''
+  id: 'person_entering_the_room' # unique id here
+  trigger:
     - platform: mqtt
       topic: "peopleCounter/serialdata/tx"
       payload: '1'
-action:
-    - data: {}
-      entity_id: input_number.people_in_the_room
-      service: input_number.increment
-mode: single
+  condition: []
+  action:
+    - service: counter.increment
+      data:
+        entity_id: counter.people_in_the_room
+  mode: single
 
 ```
 
 The following automation will take account of the case of someone exiting the room:
 
 ```yaml
-alias: 'Person exiting the room'
-description: ''
-trigger:
-- platform: mqtt
-  topic: "peopleCounter/serialdata/tx"
-  payload: '2'
-condition: []
-action:
-- data: {}
-  entity_id: input_number.people_in_the_room
-  service: input_number.decrement
-mode: single
+- alias: 'Person exiting the room'
+  description: ''
+  id: 'person_exiting_the_room' # unique id here
+  trigger:
+    - platform: mqtt
+      topic: "peopleCounter/serialdata/tx"
+      payload: '2'
+  condition: []
+  action:
+    - service: counter.decrement
+      data:
+        entity_id: counter.people_in_the_room
+  mode: single
 
 ```
-
 
 
 Finally, this automation will turn on a light when there is at least one person in the room:
 
 ```yaml
-alias: 'Turn on the light'
-trigger:
-- entity_id: input_number.people_in_the_room
-  above: '0'
-  platform: numeric_state
-action:
-- data: {}
-  entity_id: switch.light_in_the_room
-  service: switch.turn_on
-mode: single
+- alias: 'Turn on the light'
+  description: ''
+  id: 'turn_on_the_light' # unique id here
+  trigger:
+    - entity_id: counter.people_in_the_room
+      above: '0'
+      platform: numeric_state
+  action:
+    - service: switch.turn_on
+      entity_id: switch.light_in_the_room
+  mode: single
 ```
 
 and this one turns the light off when the last person gets out of the room:
 
 ```yaml
-alias: 'Turn the light off'
-description: ''
-trigger:
-- entity_id: input_number.people_in_the_room
-  below: '1'
-  platform: numeric_state
-condition: []
-action:
-- data: {}
-  entity_id: switch.light_in_the_room
-  service: switch.turn_off
-mode: single
+- alias: 'Turn the light off'
+  description: ''
+  id: 'turn_off_the_light' # unique id here
+  trigger:
+    - entity_id: counter.people_in_the_room
+      below: '1'
+      platform: numeric_state
+  condition: []
+  action:
+    - service: switch.turn_off
+      entity_id: switch.light_in_the_room
+  mode: single
 
 ```
 


### PR DESCRIPTION
https://www.home-assistant.io/integrations/counter/
A state of an input_number can be changed in the UI so that could possibly mess up the automations. 
Secondly, I also changed the layout of the automations a bit so it's more uniform and corresponding with the examples on the home-assistant.io website.
Lastly, also as an improvement I would suggest you could get also way with just two automations using the chooser. See 'make smarter automations, not more automations' from the Home Assistant Conference 2020 https://www.youtube.com/watch?v=OIkZWF5uGxk . I'm unsure if doing that would make it more or less comprehensive as an explanation, but the chooser is really powerful in HomeAssistant.